### PR TITLE
Replace go get with go install in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Check the [releases](https://github.com/freshautomations/sconfig/releases) page.
 ## How to build it from source
 Install [Golang](https://golang.org/doc/install), then run:
 ```bash
-go get github.com/freshautomations/sconfig
+go install github.com/freshautomations/sconfig@latest
 ```
 
 ## How to use


### PR DESCRIPTION
`go get` is designed to download library source code and manage go.mod file, in other words `go get` is a command for developers.

Users willing to install sconfig and use it on CLI, should use `go install`.